### PR TITLE
style: 로그인/랜딩 그레이 톤 + 카드 톤 폴리싱

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="bright" data-palette="ivory">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -30,6 +30,10 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
       <title>React App</title>
+      <script>
+          document.documentElement.setAttribute('data-theme','bright');
+          document.documentElement.setAttribute('data-palette','aurora');
+      </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,19 @@
 /* =========================
    Base / Reset
 ========================= */
+@font-face{
+    font-family: "SUIT Variable";
+    src: url("https://cdn.jsdelivr.net/gh/sunn-us/SUIT/fonts/variable/woff2/SUIT-Variable.woff2")
+    format("woff2-variations");
+    font-weight: 100 900;
+    font-style: normal;
+    font-display: swap;
+}
 :root{
+    --font-sans: "SUIT Variable", -apple-system, system-ui,
+    "Noto Sans KR", "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, "Apple SD Gothic Neo",
+    "Malgun Gothic", sans-serif;
     /* Aurora Blue 팔레트 */
     --brand-1: oklch(0.70 0.12 270);
     --brand-2: oklch(0.64 0.18 320);
@@ -12,6 +24,13 @@
     --glass-bd: rgba(255,255,255,.18);
     --glass-bg-hover: rgba(255,255,255,.14);
     --text-weak: #a9acb3;
+}
+html, body{
+    font-family: var(--font-sans);
+    letter-spacing: -0.01em;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
 html, body, #root { height: 100%; margin: 0; }
@@ -592,5 +611,1166 @@ html[data-theme="dark"]  .auth{ background: var(--right-gray) !important; }
     .landing::after{ display:none; }
     .auth__card{ margin-left: 0; }
 }
+/* =========================================
+   MAIN (로그인 후) 레이아웃 & 컴포넌트
+   ─ mac-titlebar / mac-container / mac-sidebar / mac-content
+   ─ mac-grid / mac-card / mac-window / mac-list / empty-state
+========================================= */
+
+/* 상단 타이틀바 */
+.mac-titlebar{
+    height: 48px;
+    display: flex; align-items: center;
+    padding: 0 14px;
+    background: linear-gradient(90deg, var(--brand-2), var(--brand-1));
+    border-bottom: 1px solid #ffffff22;
+    box-shadow: 0 6px 20px rgba(0,0,0,.28);
+}
+.mac-title{ font-weight: 800; letter-spacing:-.2px; }
+
+/* 전체 레이아웃 */
+#mainPage{ height: 100vh; display: flex; flex-direction: column; }
+.mac-container{
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    height: calc(100vh - 48px);
+}
+
+/* 사이드바 */
+.mac-sidebar{
+    display: flex; flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    background: #0f1218;
+    border-right: 1px solid #181b23;
+}
+.sidebar-item{
+    display: flex; align-items: center; gap: 10px;
+    padding: 12px 12px;
+    border-radius: 12px;
+    color: #cfd3de;
+    cursor: pointer;
+    user-select: none;
+    transition: background .15s ease, color .15s ease, box-shadow .15s ease;
+}
+.sidebar-item:hover{ background:#151a22; color:#fff; }
+.sidebar-item.active{
+    background:#1b2030; color:#fff;
+    box-shadow: inset 0 0 0 1px #242a3a;
+}
+
+/* 본문 */
+.mac-content{
+    position: relative;
+    overflow: auto;
+    padding: 18px;
+}
+
+/* 히어로 비주얼(윈도우 카드 재활용) */
+.mac-window{
+    background:#11151c;
+    border:1px solid #1e2431;
+    border-radius:16px;
+    box-shadow: 0 10px 24px rgba(0,0,0,.32);
+}
+.mac-window > h2{ margin:0; padding:14px 16px; border-bottom:1px solid #1c2230; }
+.mac-window-content{ padding:16px; }
+
+/* 카드 그리드 */
+.mac-grid{
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+}
+@media (min-width: 1100px){
+    .mac-grid{ grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+/* 기능 카드 */
+.mac-card{
+    all: unset;
+    background:#131823;
+    border:1px solid #1e2636;
+    border-radius:18px;
+    padding: 18px;
+    display: grid; gap: 6px;
+    cursor: pointer;
+    box-shadow: 0 10px 22px rgba(0,0,0,.28);
+    transition: transform .08s ease, box-shadow .2s ease, background .15s ease, border-color .15s ease;
+}
+.mac-card i{ opacity:.95; }
+.mac-card h3{ margin:6px 0 0; font-size:18px; }
+.mac-card p{ margin:2px 0 0; color:#a8afbc; font-size:13px; }
+.mac-card:hover{
+    transform: translateY(-2px);
+    background:#161d2b;
+    border-color:#2a3550;
+    box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 3px oklch(0.72 0.10 270 / .28);
+}
+
+/* 리스트/빈 상태 */
+.mac-list{ display: grid; gap: 10px; }
+.list-group-item{
+    background:#121722; border:1px solid #1f2634; border-radius:12px; padding:12px;
+}
+.empty-state{
+    text-align:center; padding:40px 12px; color:#aab0bd;
+}
+
+/* 배지/텍스트 버튼(부트스트랩 미사용 대비) */
+.badge{ display:inline-block; font-size:12px; padding:6px 10px; border-radius:999px; }
+.bg-dark{ background:#232838; color:#e8ecff; }
+.text-btn{ all:unset; color:#9da6ff; cursor:pointer; }
+.text-btn:hover{ text-decoration: underline; }
+
+/* 버튼(간단 버전) */
+.btn{ display:inline-flex; align-items:center; gap:8px; border-radius:10px; padding:8px 12px; font-weight:600; cursor:pointer; border:1px solid transparent; }
+.btn-sm{ padding:6px 10px; font-size:12px; }
+.btn-dark{ background:#2b2f44; color:#fff; border-color:#3a3f58; }
+.btn-outline-dark{ background:transparent; color:#cfd3de; border-color:#3a3f58; }
+.btn-primary{ background: oklch(0.62 0.16 320); border-color: transparent; color:#fff; }
+.btn-secondary{ background:#1a1f2c; color:#d9deea; border-color:#2a3144; }
+.btn:hover{ filter: brightness(1.06); }
+
+/* 스크롤바 살짝 */
+.mac-content::-webkit-scrollbar{ height:10px; width:10px; }
+.mac-content::-webkit-scrollbar-thumb{ background:#2a3042; border-radius:999px; }
+.mac-content::-webkit-scrollbar-track{ background:transparent; }
+
+/* 라이트 테마 보정 */
+html[data-theme="light"] .mac-sidebar{ background:#f3f6ff; border-color:#e6eaf6; }
+html[data-theme="light"] .sidebar-item{ color:#334155; }
+html[data-theme="light"] .sidebar-item:hover{ background:#e9eefc; color:#0e1220; }
+html[data-theme="light"] .sidebar-item.active{ background:#e2e8ff; box-shadow: inset 0 0 0 1px #c9d3ff; }
+html[data-theme="light"] .mac-content{ color:#0e1220; }
+html[data-theme="light"] .mac-window{ background:#ffffff; border-color:#e7ebf5; }
+html[data-theme="light"] .mac-card{ background:#ffffff; border-color:#e7ebf5; box-shadow: 0 10px 26px rgba(15,23,42,.10); }
+html[data-theme="light"] .mac-card:hover{ border-color:#cfd8ff; box-shadow: 0 14px 34px rgba(15,23,42,.16), 0 0 0 3px rgba(86,104,255,.18); }
+html[data-theme="light"] .list-group-item{ background:#ffffff; border-color:#e7ebf5; }
+html[data-theme="light"] .bg-dark{ background:#e9edff; color:#3945a8; }
+html[data-theme="light"] .btn-dark{ background:#334155; }
+html[data-theme="light"] .btn-outline-dark{ color:#334155; border-color:#c7cfdf; }
+/* --- 사이드바 제거용 단일 레이아웃 --- */
+.mac-container.no-sidebar{
+    grid-template-columns: 1fr; /* 한 컬럼만 */
+}
+
+/* 본문 패딩/폭 */
+.mac-content--padded{
+    padding: 18px;
+    max-width: 1160px;
+    margin: 0 auto;
+}
+
+/* 페이지 상단 액션(메인으로) */
+.top-actions{
+    display:flex; justify-content:flex-start; margin-bottom:12px;
+}
+
+/* 6개 카드 그리드: 모바일 2열 → 데스크톱 3열 */
+.cards-6{
+    display:grid;
+    grid-template-columns: repeat(2, minmax(0,1fr));
+    gap: 16px;
+}
+@media (min-width: 980px){
+    .cards-6{ grid-template-columns: repeat(3, minmax(0,1fr)); }
+}
+
+/* mac-card는 기존 스타일 재사용 (이미 정의됨) */
+/* ====== 홈 상단 히어로(컴팩트) ====== */
+.home-hero{
+    display:flex; align-items:center; justify-content:space-between;
+    gap:16px;
+    margin: 8px 0 14px;
+    padding: 14px 18px;
+    background:#10141c;
+    border:1px solid #1c2231;
+    border-radius:16px;
+    box-shadow: 0 10px 24px rgba(0,0,0,.28);
+}
+.home-hero h2{ margin:0 0 4px 0; font-size:20px; }
+.home-hero p{ margin:0; color:#aeb4c2; font-size:13px; }
+
+.chips{ display:flex; gap:8px; flex-wrap:wrap; }
+.chip{
+    padding:6px 10px; border-radius:999px; font-size:12px; color:#cfd6e8;
+    background:#192032; border:1px solid #273149;
+}
+
+/* ====== 패널 헤더 ====== */
+.section-head{ display:flex; align-items:center; justify-content:space-between; margin:2px 0 10px; }
+.section-head h3{ margin:0; font-size:16px; }
+
+/* ====== 컨테이너 밀도 조정 ====== */
+.mac-content--padded{ padding:16px; max-width:1100px; margin:0 auto; }
+
+/* ====== 6카드 그리드: 촘촘 모드 ====== */
+.cards-6{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:14px; }
+.cards-6.tight .mac-card{ min-height:110px; }
+@media (min-width: 980px){
+    .cards-6{ grid-template-columns: repeat(3, minmax(0,1fr)); }
+}
+
+/* ====== 액션 카드(아이콘 + 텍스트 좌우배치) ====== */
+.mac-card.action{ padding:14px 14px; }
+.card-row{ display:flex; align-items:center; gap:12px; }
+.card-icon{
+    width:40px; height:40px; border-radius:12px;
+    display:flex; align-items:center; justify-content:center;
+    background:#172034; border:1px solid #26324a;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.03);
+}
+.card-icon i{ font-size:18px; opacity:.95; }
+.card-text{ display:grid; gap:2px; text-align:left; }
+.card-title{ font-weight:800; font-size:15px; }
+.card-sub{ color:#99a3b7; font-size:12px; }
+
+/* 호버 강화(밀도 유지) */
+.mac-card.action:hover{
+    transform: translateY(-1px);
+    border-color:#33406a;
+    box-shadow: 0 12px 28px rgba(0,0,0,.34), 0 0 0 3px oklch(0.72 0.10 270 / .22);
+}
+
+/* 라이트 테마 보정 */
+html[data-theme="light"] .home-hero{ background:#ffffff; border-color:#e6eaf5; }
+html[data-theme="light"] .chip{ background:#eef2ff; border-color:#d9e0ff; color:#334155; }
+html[data-theme="light"] .card-icon{ background:#f3f6ff; border-color:#e0e7ff; }
+html[data-theme="light"] .card-sub{ color:#5b6476; }
+/* ===== 카드 그리드: 더 크게/촘촘하게 ===== */
+.cards-6.big{ gap:18px; }
+@media (min-width: 980px){ .cards-6.big{ grid-template-columns: repeat(3, minmax(0,1fr)); } }
+
+/* ===== 카드 크기 업 + 밝은 톤 ===== */
+.mac-card.action.lg{
+    padding:18px 18px;
+    min-height: 160px;            /* ← 카드 높이 업 */
+    background: #0f1623;          /* 기존보다 약간 더 밝은 남색 */
+    border: 1px solid #223049;
+}
+.mac-card.action.lg:hover{
+    background:#121c2c;
+    border-color:#33466b;
+}
+
+/* 아이콘 배지(이모지 컨테이너) */
+.card-row{ display:flex; align-items:center; gap:14px; }
+.card-icon{
+    width:56px; height:56px;      /* ← 아이콘 박스 크게 */
+    border-radius:14px;
+    display:flex; align-items:center; justify-content:center;
+    background:#17243a; border:1px solid #2a3b57;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.03);
+    flex:0 0 56px;
+}
+.card-emoji{ font-size:26px; line-height:1; }
+.card-title{ font-weight:800; font-size:18px; }
+.card-sub{ color:#9eabc1; font-size:13px; }
+
+/* 호버 링 */
+.mac-card.action.lg:hover{
+    transform: translateY(-2px);
+    box-shadow: 0 14px 34px rgba(0,0,0,.38);
+}
+
+/* ===== 악센트(포인트 컬러) ===== */
+/* 보조 변수 느낌의 투명 링 컬러를 각 악센트에 적용 */
+.mac-card.accent-violet:hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 4px rgba(139,92,246,.22); }
+.mac-card.accent-mint:hover  { box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 4px rgba(45,212,191,.22); }
+.mac-card.accent-amber:hover { box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 4px rgba(245,158,11,.22); }
+.mac-card.accent-pink:hover  { box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 4px rgba(236,72,153,.22); }
+.mac-card.accent-blue:hover  { box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 4px rgba(96,165,250,.22); }
+.mac-card.accent-lime:hover  { box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 4px rgba(132,204,22,.22); }
+
+/* 아이콘 배지 배경에도 살짝 그라데이션 포인트 */
+.mac-card.accent-violet .card-icon{
+    background: radial-gradient(110% 110% at 30% 30%, rgba(167,139,250,.25), transparent 60%), #17243a;
+    border-color:#3a2f6b;
+}
+.mac-card.accent-mint .card-icon{
+    background: radial-gradient(110% 110% at 30% 30%, rgba(45,212,191,.25), transparent 60%), #17243a;
+    border-color:#1d5c5a;
+}
+.mac-card.accent-amber .card-icon{
+    background: radial-gradient(110% 110% at 30% 30%, rgba(245,158,11,.25), transparent 60%), #17243a;
+    border-color:#5a4530;
+}
+.mac-card.accent-pink .card-icon{
+    background: radial-gradient(110% 110% at 30% 30%, rgba(236,72,153,.25), transparent 60%), #17243a;
+    border-color:#5a2d49;
+}
+.mac-card.accent-blue .card-icon{
+    background: radial-gradient(110% 110% at 30% 30%, rgba(96,165,250,.25), transparent 60%), #17243a;
+    border-color:#284b73;
+}
+.mac-card.accent-lime .card-icon{
+    background: radial-gradient(110% 110% at 30% 30%, rgba(132,204,22,.25), transparent 60%), #17243a;
+    border-color:#415a26;
+}
+
+/* 라이트 테마 보정(더 화사하게) */
+html[data-theme="light"] .mac-card.action.lg{
+    background:#ffffff; border-color:#e6eaf5;
+    box-shadow: 0 10px 26px rgba(15,23,42,.10);
+}
+html[data-theme="light"] .card-icon{
+    background:#f3f6ff; border-color:#e0e7ff;
+}
+html[data-theme="light"] .card-sub{ color:#5b6476; }
+/* ===============================
+   COHESIVE COLOR SYSTEM (Dark/Light)
+   - 화면 전역 톤 통일
+   - 카드/패널/텍스트/보더 변수화
+================================== */
+:root{
+    /* Dark base: 딥 네이비 */
+    --bg-0: oklch(0.16 0.02 260); /* 페이지 배경 */
+    --bg-1: oklch(0.20 0.02 260); /* 패널/히어로 */
+    --bg-2: oklch(0.24 0.03 260); /* 카드 */
+    --line-1: oklch(0.34 0.02 260 / .36);
+
+    --txt-1: oklch(0.93 0.02 260); /* 본문/제목 */
+    --txt-2: oklch(0.78 0.02 260); /* 보조 */
+
+    --shadow-1: 0 10px 24px rgba(0,0,0,.35);
+
+    /* Accent palette (OKLCH로 선명도 유지) */
+    --acc-violet: oklch(0.72 0.18 300);
+    --acc-mint:   oklch(0.83 0.11 170);
+    --acc-amber:  oklch(0.82 0.14 80);
+    --acc-pink:   oklch(0.78 0.19 350);
+    --acc-blue:   oklch(0.78 0.12 250);
+    --acc-lime:   oklch(0.87 0.14 130);
+    --acc-ring-a: .22; /* 호버 링 알파 */
+}
+
+/* Light theme 토큰 */
+html[data-theme="light"]{
+    --bg-0: #f5f7ff;
+    --bg-1: #ffffff;
+    --bg-2: #ffffff;
+    --line-1: #e6eaf5;
+    --txt-1: #0e1220;
+    --txt-2: #5b6476;
+    --shadow-1: 0 10px 26px rgba(15,23,42,.10);
+}
+
+/* 전역 적용 */
+body{ background:var(--bg-0); color:var(--txt-1); }
+
+/* 상단 히어로/패널/카드 통일 */
+.home-hero,
+.mac-window{ background:var(--bg-1); border:1px solid var(--line-1); box-shadow:var(--shadow-1); }
+.mac-card.action.lg{ background:var(--bg-2); border:1px solid var(--line-1); }
+
+/* 텍스트/칩 톤 */
+.card-title{ color:var(--txt-1); }
+.card-sub{ color:var(--txt-2); }
+.home-hero p{ color:var(--txt-2); }
+.chip{ background:var(--bg-2); border:1px solid var(--line-1); color:var(--txt-2); }
+
+/* 아이콘 배지의 기본(악센트 없을 때) */
+.card-icon{
+    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-2) 92%, white 8%), var(--bg-2));
+    border-color: var(--line-1);
+}
+
+/* Hover: 살짝 선명/밝게 */
+.mac-card.action.lg:hover{
+    background: color-mix(in oklab, var(--bg-2) 90%, white 10%);
+    transform: translateY(-2px);
+    box-shadow: 0 14px 34px rgba(0,0,0,.38);
+}
+
+/* ===== Accent mapping (카드에 class="accent-*" 사용) ===== */
+.mac-card.accent-violet:hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px color-mix(in oklab, var(--acc-violet) 100%, transparent calc(100% - (var(--acc-ring-a)*100%))); }
+.mac-card.accent-mint  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px color-mix(in oklab, var(--acc-mint)   100%, transparent calc(100% - (var(--acc-ring-a)*100%))); }
+.mac-card.accent-amber :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px color-mix(in oklab, var(--acc-amber)  100%, transparent calc(100% - (var(--acc-ring-a)*100%))); }
+.mac-card.accent-pink  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px color-mix(in oklab, var(--acc-pink)   100%, transparent calc(100% - (var(--acc-ring-a)*100%))); }
+.mac-card.accent-blue  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px color-mix(in oklab, var(--acc-blue)   100%, transparent calc(100% - (var(--acc-ring-a)*100%))); }
+.mac-card.accent-lime  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px color-mix(in oklab, var(--acc-lime)   100%, transparent calc(100% - (var(--acc-ring-a)*100%))); }
+
+/* 아이콘 배지에 악센트 하이라이트(과하지 않게) */
+.mac-card.accent-violet .card-icon{ background:
+        radial-gradient(120% 120% at 28% 28%, color-mix(in oklab, var(--acc-violet) 28%, transparent) 0%, transparent 60%),
+        var(--bg-2); border-color: color-mix(in oklab, var(--acc-violet) 32%, var(--line-1)); }
+.mac-card.accent-mint .card-icon{ background:
+        radial-gradient(120% 120% at 28% 28%, color-mix(in oklab, var(--acc-mint) 28%, transparent) 0%, transparent 60%),
+        var(--bg-2); border-color: color-mix(in oklab, var(--acc-mint) 32%, var(--line-1)); }
+.mac-card.accent-amber .card-icon{ background:
+        radial-gradient(120% 120% at 28% 28%, color-mix(in oklab, var(--acc-amber) 28%, transparent) 0%, transparent 60%),
+        var(--bg-2); border-color: color-mix(in oklab, var(--acc-amber) 32%, var(--line-1)); }
+.mac-card.accent-pink .card-icon{ background:
+        radial-gradient(120% 120% at 28% 28%, color-mix(in oklab, var(--acc-pink) 28%, transparent) 0%, transparent 60%),
+        var(--bg-2); border-color: color-mix(in oklab, var(--acc-pink) 32%, var(--line-1)); }
+.mac-card.accent-blue .card-icon{ background:
+        radial-gradient(120% 120% at 28% 28%, color-mix(in oklab, var(--acc-blue) 28%, transparent) 0%, transparent 60%),
+        var(--bg-2); border-color: color-mix(in oklab, var(--acc-blue) 32%, var(--line-1)); }
+.mac-card.accent-lime .card-icon{ background:
+        radial-gradient(120% 120% at 28% 28%, color-mix(in oklab, var(--acc-lime) 28%, transparent) 0%, transparent 60%),
+        var(--bg-2); border-color: color-mix(in oklab, var(--acc-lime) 32%, var(--line-1)); }
+
+/* 라이트 모드에서도 조화롭게 */
+html[data-theme="light"] .home-hero,
+html[data-theme="light"] .mac-window{ background:var(--bg-1); border-color:var(--line-1); box-shadow:var(--shadow-1); }
+html[data-theme="light"] .mac-card.action.lg{ background:var(--bg-2); border-color:var(--line-1); }
+html[data-theme="light"] .mac-card.action.lg:hover{
+    background: color-mix(in oklab, var(--bg-2) 92%, black 8%);
+}
+
+/* 페이지 빈공간을 살짝 다듬는 배경 하이라이트(아주 미세) */
+#mainPage::before{
+    content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
+    background:
+            radial-gradient(800px 400px at 50% 140px, rgba(255,255,255,.05), transparent 60%),
+            radial-gradient(600px 600px at 50% 60%, rgba(123,97,255,.06), transparent 70%);
+}
+/* =========================================
+   FORCE OVERRIDE + FALLBACK (put at very end)
+   - 상위 규칙/!important 덮어쓰고
+   - oklch 미지원 시에도 헥사 값으로 적용
+========================================= */
+
+/* 1) 폴백용 헥사 팔레트 */
+:root{
+    --bg0-hex:#0e1118;  /* 페이지 */
+    --bg1-hex:#101521;  /* 패널/히어로 */
+    --bg2-hex:#121a2a;  /* 카드 */
+    --ln1-hex:#2a3446;  /* 보더 */
+    --t1-hex:#ecf0ff;   /* 본문/제목 */
+    --t2-hex:#aab3c6;   /* 보조 */
+    --sh1:0 10px 24px rgba(0,0,0,.35);
+    /* 악센트 링 농도 */
+    --accA:.24;
+}
+
+/* 2) 전역 토큰 (oklch 지원엔 이 값이 쓰이고, 미지원이면 아래 폴백 값이 유지됨) */
+:root{
+    --bg-0: oklch(0.16 0.02 260);
+    --bg-1: oklch(0.20 0.02 260);
+    --bg-2: oklch(0.24 0.03 260);
+    --line-1: oklch(0.34 0.02 260 / .36);
+    --txt-1: oklch(0.93 0.02 260);
+    --txt-2: oklch(0.78 0.02 260);
+}
+html[data-theme="light"]{
+    --bg-0:#f5f7ff; --bg-1:#ffffff; --bg-2:#ffffff;
+    --line-1:#e6eaf5; --txt-1:#0e1220; --txt-2:#5b6476;
+}
+
+/* 3) 실제 적용 (항상 '헥사 → 변수' 두 줄, 그리고 !important) */
+body{
+    background: var(--bg0-hex) !important;
+    background: var(--bg-0) !important;
+    color: var(--t1-hex) !important;
+    color: var(--txt-1) !important;
+}
+
+.home-hero, .mac-window{
+    background: var(--bg1-hex) !important;
+    background: var(--bg-1) !important;
+    border: 1px solid var(--ln1-hex) !important;
+    border-color: var(--line-1) !important;
+    box-shadow: var(--sh1) !important;
+}
+
+.mac-card.action.lg{
+    background: var(--bg2-hex) !important;
+    background: var(--bg-2) !important;
+    border: 1px solid var(--ln1-hex) !important;
+    border-color: var(--line-1) !important;
+}
+.mac-card.action.lg:hover{
+    background: #162136 !important; /* 살짝 밝게 */
+}
+
+.card-title{ color: var(--t1-hex) !important; color: var(--txt-1) !important; }
+.card-sub, .home-hero p{
+    color: var(--t2-hex) !important; color: var(--txt-2) !important;
+}
+.chip{
+    background: var(--bg2-hex) !important;
+    background: var(--bg-2) !important;
+    border: 1px solid var(--ln1-hex) !important;
+    border-color: var(--line-1) !important;
+    color: var(--t2-hex) !important; color: var(--txt-2) !important;
+}
+
+/* 4) 악센트 링(hover)도 통일감 있게 */
+.mac-card.accent-violet:hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px rgba(139,92,246,var(--accA)); }
+.mac-card.accent-mint  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px rgba(45,212,191,var(--accA)); }
+.mac-card.accent-amber :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px rgba(245,158,11,var(--accA)); }
+.mac-card.accent-pink  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px rgba(236,72,153,var(--accA)); }
+.mac-card.accent-blue  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px rgba(96,165,250,var(--accA)); }
+.mac-card.accent-lime  :hover{ box-shadow: 0 14px 34px rgba(0,0,0,.38), 0 0 0 5px rgba(132,204,22,var(--accA)); }
+/* =========================
+   THEME OVERRIDE (FINAL)
+   붙여넣기 위치: App.css "맨 아래"
+========================= */
+:root{
+    /* Dark */
+    --bg-0:#0e1118;  /* 페이지 배경 */
+    --bg-1:#101521;  /* 패널/히어로 */
+    --bg-2:#121a2a;  /* 카드 */
+    --line-1:#2a3446;/* 보더 */
+    --txt-1:#ecf0ff; /* 본문/제목 */
+    --txt-2:#aab3c6; /* 보조 */
+    --shadow-1:0 10px 24px rgba(0,0,0,.35);
+
+    /* Accents */
+    --acc-violet:#8b5cf6;
+    --acc-mint:#2dd4bf;
+    --acc-amber:#f59e0b;
+    --acc-pink:#ec4899;
+    --acc-blue:#60a5fa;
+    --acc-lime:#84cc16;
+    --accA:.24; /* hover 링 투명도 */
+}
+
+/* Light */
+html[data-theme="light"]{
+    --bg-0:#f5f7ff; --bg-1:#ffffff; --bg-2:#ffffff;
+    --line-1:#e6eaf5; --txt-1:#0e1220; --txt-2:#5b6476;
+    --shadow-1:0 10px 26px rgba(15,23,42,.10);
+}
+
+/* 전역 */
+body{
+    background:var(--bg-0) !important;
+    color:var(--txt-1) !important;
+}
+
+/* 패널/히어로/카드 */
+.home-hero,.mac-window{
+    background:var(--bg-1) !important;
+    border:1px solid var(--line-1) !important;
+    box-shadow:var(--shadow-1) !important;
+}
+.mac-card.action.lg{
+    background:var(--bg-2) !important;
+    border:1px solid var(--line-1) !important;
+}
+.mac-card.action.lg:hover{
+    background:#162136 !important;   /* 살짝 밝게 */
+    transform:translateY(-2px);
+    box-shadow:0 14px 34px rgba(0,0,0,.38) !important;
+}
+
+/* 텍스트/칩/아이콘 배지 */
+.card-title{ color:var(--txt-1) !important; }
+.card-sub,.home-hero p{ color:var(--txt-2) !important; }
+
+.chip{
+    background:var(--bg-2) !important;
+    border:1px solid var(--line-1) !important;
+    color:var(--txt-2) !important;
+}
+
+.card-icon{
+    background:linear-gradient(180deg,#1b2740,#17243a) !important;
+    border:1px solid #2a3b57 !important;
+}
+
+/* 악센트 호버 링 */
+.mac-card.accent-violet:hover{ box-shadow:0 14px 34px rgba(0,0,0,.38),0 0 0 5px rgba(139,92,246,var(--accA)) !important; }
+.mac-card.accent-mint:hover  { box-shadow:0 14px 34px rgba(0,0,0,.38),0 0 0 5px rgba(45,212,191,var(--accA)) !important; }
+.mac-card.accent-amber:hover { box-shadow:0 14px 34px rgba(0,0,0,.38),0 0 0 5px rgba(245,158,11,var(--accA)) !important; }
+.mac-card.accent-pink:hover  { box-shadow:0 14px 34px rgba(0,0,0,.38),0 0 0 5px rgba(236,72,153,var(--accA)) !important; }
+.mac-card.accent-blue:hover  { box-shadow:0 14px 34px rgba(0,0,0,.38),0 0 0 5px rgba(96,165,250,var(--accA)) !important; }
+.mac-card.accent-lime:hover  { box-shadow:0 14px 34px rgba(0,0,0,.38),0 0 0 5px rgba(132,204,22,var(--accA)) !important; }
+
+/* 페이지 배경 하이라이트(은은) */
+#mainPage::before{
+    content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
+    background:
+            radial-gradient(800px 400px at 50% 140px, rgba(255,255,255,.05), transparent 60%),
+            radial-gradient(600px 600px at 50% 60%, rgba(123,97,255,.06), transparent 70%); }
+/* =========================================================
+   BRIGHT THEME (전체를 밝고 세련되게)
+   paste at the VERY END of App.css
+========================================================= */
+
+/* 1) 토큰: 페이지/카드/보더/텍스트 */
+html[data-theme="bright"]{
+    /* Base */
+    --bg-0: #F7FAFF;   /* 페이지 배경 */
+    --bg-1: #FFFFFF;   /* 패널/히어로/카드 상위 */
+    --bg-2: #FFFFFF;   /* 카드 */
+    --line-1: #E8EDF8; /* 경계선 */
+    --txt-1: #0B1220;  /* 본문/제목 */
+    --txt-2: #5B6476;  /* 보조 텍스트 */
+    --shadow-1: 0 12px 28px rgba(15,23,42,.10);
+
+    /* Brand & accents (보라 중심, 블루 보조) */
+    --brand-1: #8B5CF6;      /* violet 500 */
+    --brand-2: #60A5FA;      /* blue 400 */
+    --brand-3: #C4B5FD;      /* violet 300 */
+    --brand-spot: rgba(139,92,246,.10);
+
+    --acc-violet:#8B5CF6;
+    --acc-mint:#2DD4BF;
+    --acc-amber:#F59E0B;
+    --acc-pink:#EC4899;
+    --acc-blue:#60A5FA;
+    --acc-lime:#84CC16;
+    --accA:.16; /* hover 링 투명도(밝은 톤이라 낮춤) */
+}
+
+/* 2) 전역 배경/텍스트 */
+html[data-theme="bright"] body{
+    background: var(--bg-0) !important;
+    color: var(--txt-1) !important;
+}
+
+/* 3) 로그인 화면(오른쪽) – 너무 많은 이펙트 제거 + 라이트 톤 */
+html[data-theme="bright"] .auth{
+    background:
+            radial-gradient(1200px 600px at 60% -10%, rgba(255,255,255,.9) 0%, transparent 60%),
+            linear-gradient(180deg, #EEF3FF 0%, #EAF0FF 50%, #E7ECFA 100%);
+}
+html[data-theme="bright"] .auth::before,
+html[data-theme="bright"] .auth::after{ content:none !important; }
+
+html[data-theme="bright"] .auth__card{
+    background:#FFFFFF;
+    border:1px solid #E6EAF5;
+    border-radius:20px;
+    box-shadow:
+            0 1px 0 rgba(255,255,255,.9) inset,
+            0 8px 16px rgba(15,23,42,.06),
+            0 28px 60px rgba(15,23,42,.10) !important;
+}
+html[data-theme="bright"] .auth__card::before,
+html[data-theme="bright"] .auth__card::after{ content:none !important; }
+
+html[data-theme="bright"] .auth__title{ color:#1F2430 !important; }
+html[data-theme="bright"] .auth__sub{ color:#48505B !important; }
+html[data-theme="bright"] .auth__divider{ color:#6E7682 !important; }
+html[data-theme="bright"] .auth__benefits{ color:#2F343B !important; }
+html[data-theme="bright"] .auth__meta{ color:#5A6270 !important; }
+html[data-theme="bright"] .auth__meta a{ color:#2B4ACB !important; }
+
+/* 구글 버튼 컨테이너(버튼 자체는 정책상 제한) */
+html[data-theme="bright"] #googleSignInDiv > div{
+    width:100% !important;
+    border:1px solid #E6E9F2 !important;
+    border-radius:12px !important;
+    box-shadow: 0 1px 2px rgba(15,23,42,.05), 0 2px 8px rgba(15,23,42,.06) !important;
+}
+
+/* 4) 상단 타이틀바 – 파스텔 그래디언트 */
+html[data-theme="bright"] .mac-titlebar{
+    background: linear-gradient(90deg, #A78BFA, #93C5FD);
+    border-bottom:1px solid #E8EDF8;
+    box-shadow: 0 8px 22px rgba(93,109,180,.18);
+}
+html[data-theme="bright"] .mac-title{ color:#0B1220; }
+
+/* 5) 전체 레이아웃/사이드바/콘텐츠 */
+html[data-theme="bright"] .mac-container{ background:transparent; }
+html[data-theme="bright"] .mac-sidebar{
+    background:#F3F6FF;
+    border-right:1px solid #E6EAF5;
+}
+html[data-theme="bright"] .sidebar-item{
+    color:#334155;
+    background:transparent;
+    border:1px solid transparent;
+}
+html[data-theme="bright"] .sidebar-item:hover{
+    background:#E9EEFC; color:#0E1220;
+}
+html[data-theme="bright"] .sidebar-item.active{
+    background:#E2E8FF; color:#0E1220;
+    box-shadow: inset 0 0 0 1px #C9D3FF;
+}
+
+/* 6) 카드/윈도우/칩 – 라이트 톤 */
+html[data-theme="bright"] .home-hero,
+html[data-theme="bright"] .mac-window{
+    background: var(--bg-1) !important;
+    border:1px solid var(--line-1) !important;
+    box-shadow: var(--shadow-1) !important;
+}
+html[data-theme="bright"] .home-hero p{ color:var(--txt-2); }
+
+html[data-theme="bright"] .mac-card.action.lg{
+    background: var(--bg-2) !important;
+    border:1px solid var(--line-1) !important;
+    box-shadow: 0 10px 26px rgba(15,23,42,.10);
+}
+html[data-theme="bright"] .mac-card.action.lg:hover{
+    transform: translateY(-2px);
+    background: #FFFFFF;
+    border-color:#CFD8FF !important;
+    box-shadow: 0 14px 34px rgba(15,23,42,.16), 0 0 0 3px rgba(86,104,255,.16) !important;
+}
+
+html[data-theme="bright"] .card-icon{
+    background:#F3F6FF; border:1px solid #E0E7FF;
+}
+html[data-theme="bright"] .card-title{ color:var(--txt-1); }
+html[data-theme="bright"] .card-sub{ color:var(--txt-2); }
+
+html[data-theme="bright"] .chip{
+    background:#EEF2FF;
+    border:1px solid #D9E0FF;
+    color:#334155;
+}
+
+/* 7) 악센트 호버 링 – 파스텔 농도 */
+html[data-theme="bright"] .mac-card.accent-violet:hover{ box-shadow:0 14px 34px rgba(0,0,0,.14),0 0 0 4px rgba(139,92,246,.18) !important; }
+html[data-theme="bright"] .mac-card.accent-mint:hover  { box-shadow:0 14px 34px rgba(0,0,0,.14),0 0 0 4px rgba(45,212,191,.18) !important; }
+html[data-theme="bright"] .mac-card.accent-amber:hover { box-shadow:0 14px 34px rgba(0,0,0,.14),0 0 0 4px rgba(245,158,11,.18) !important; }
+html[data-theme="bright"] .mac-card.accent-pink:hover  { box-shadow:0 14px 34px rgba(0,0,0,.14),0 0 0 4px rgba(236,72,153,.18) !important; }
+html[data-theme="bright"] .mac-card.accent-blue:hover  { box-shadow:0 14px 34px rgba(0,0,0,.14),0 0 0 4px rgba(96,165,250,.18) !important; }
+html[data-theme="bright"] .mac-card.accent-lime:hover  { box-shadow:0 14px 34px rgba(0,0,0,.14),0 0 0 4px rgba(132,204,22,.18) !important; }
+
+/* 8) 메인 페이지 빈 공간 하이라이트(아주 미세) */
+html[data-theme="bright"] #mainPage::before{
+    content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
+    background:
+            radial-gradient(800px 400px at 50% 120px, rgba(139,92,246,.06), transparent 60%),
+            radial-gradient(600px 600px at 60% 40%, rgba(96,165,250,.05), transparent 70%);
+}
+/* ========== BRIGHT WINS PATCH — put at the VERY END ========== */
+html[data-theme="bright"]{
+    /* 토큰 */
+    --bg-0:#F7FAFF; --bg-1:#FFFFFF; --bg-2:#FFFFFF;
+    --line-1:#E8EDF8; --txt-1:#0B1220; --txt-2:#5B6476;
+    --shadow-1:0 12px 28px rgba(15,23,42,.10);
+}
+
+html[data-theme="bright"] body{
+    background:var(--bg-0) !important;
+    color:var(--txt-1) !important;
+}
+
+/* 로그인 패널 */
+html[data-theme="bright"] .auth{
+    background:
+            radial-gradient(1200px 600px at 60% -10%, rgba(255,255,255,.9) 0%, transparent 60%),
+            linear-gradient(180deg, #EEF3FF 0%, #EAF0FF 50%, #E7ECFA 100%) !important;
+}
+html[data-theme="bright"] .auth__card{
+    background:#fff !important;
+    border:1px solid #E6EAF5 !important;
+    border-radius:20px !important;
+    box-shadow:
+            0 1px 0 rgba(255,255,255,.9) inset,
+            0 8px 16px rgba(15,23,42,.06),
+            0 28px 60px rgba(15,23,42,.10) !important;
+}
+
+/* 메인 컴포넌트 */
+html[data-theme="bright"] .home-hero,
+html[data-theme="bright"] .mac-window{
+    background:var(--bg-1) !important;
+    border:1px solid var(--line-1) !important;
+    box-shadow:var(--shadow-1) !important;
+}
+
+html[data-theme="bright"] .mac-card.action.lg{
+    background:var(--bg-2) !important;
+    border:1px solid var(--line-1) !important;
+}
+html[data-theme="bright"] .mac-card.action.lg:hover{
+    transform:translateY(-2px);
+    background:#fff !important;
+    border-color:#CFD8FF !important;
+    box-shadow:0 14px 34px rgba(15,23,42,.16), 0 0 0 3px rgba(86,104,255,.16) !important;
+}
+
+/* 카드 내부 */
+html[data-theme="bright"] .card-title{ color:var(--txt-1) !important; }
+html[data-theme="bright"] .card-sub{ color:var(--txt-2) !important; }
+html[data-theme="bright"] .card-icon{
+    background:#F3F6FF !important; border:1px solid #E0E7FF !important;
+}
+html[data-theme="bright"] .chip{
+    background:#EEF2FF !important; border:1px solid #D9E0FF !important; color:#334155 !important;
+}
+/* Bright + Ivory palette */
+:root[data-theme="bright"][data-palette="ivory"]{
+    /* Neutrals: 밝은 아이보리 */
+    --bg:#FFFBF2;               /* 페이지 배경 */
+    --surface:#FFF7E8;          /* 카드/섹션 배경 */
+    --surface-2:#FFF1DB;        /* hover용 살짝 강조 */
+    --border:#F1E6D4;
+
+    --text-strong:#221A0E;      /* 제목/강조 텍스트 */
+    --text:#2F281C;             /* 본문 */
+    --text-mute:#7E6C55;        /* 보조 텍스트 */
+
+    /* Accent (보라 포인트 유지 – 필요시 바꿔도 됨) */
+    --primary-50:#F6F2FF;
+    --primary-100:#EEE9FF;
+    --primary-300:#CFC3FF;
+    --primary-500:#8B6CF6;
+    --primary-600:#7A5AE6;
+
+    --success:#27B17D;
+    --warning:#F4A11A;
+    --danger:#E04F5F;
+
+    /* 그림자 컬러 베이스 */
+    --shadow-rgb: 28,20,10;
+}
+/* =========================================================
+   BRIGHT + IVORY — FINAL OVERRIDES
+   (Paste at the VERY END of App.css)
+   - 페이지/카드/보더/텍스트 토큰을 아이보리로 매핑
+   - 로그인 패널과 메인 카드/칩/아이콘까지 일괄 톤 변경
+========================================================= */
+
+/* 0) 아이보리 팔레트(중립 토큰) */
+html[data-theme="bright"][data-palette="ivory"]{
+    /* Neutrals (Ivory) */
+    --bg:        #FFFBF2;  /* 페이지 배경 */
+    --surface:   #FFF7E8;  /* 카드/섹션 배경 */
+    --surface-2: #FFF1DB;  /* hover용 강조 */
+    --border:    #F1E6D4;
+
+    --text-strong:#221A0E; /* 제목 */
+    --text:       #2F281C; /* 본문 */
+    --text-mute:  #7E6C55; /* 보조 */
+
+    /* (선택) 보라 악센트 유지 */
+    --primary-50:#F6F2FF;
+    --primary-100:#EEE9FF;
+    --primary-300:#CFC3FF;
+    --primary-500:#8B6CF6;
+    --primary-600:#7A5AE6;
+
+    /* 그림자 베이스 */
+    --shadow-rgb: 28,20,10;
+}
+
+/* 1) 기존 컴포넌트 토큰에 아이보리 값 매핑 */
+html[data-theme="bright"][data-palette="ivory"]{
+    --bg-0: var(--bg);
+    --bg-1: var(--surface);
+    --bg-2: var(--surface);
+    --line-1: var(--border);
+    --txt-1: var(--text-strong);
+    --txt-2: var(--text-mute);
+    --shadow-1: 0 12px 28px rgba(var(--shadow-rgb), .10);
+}
+
+/* 2) 전역 배경/텍스트 */
+html[data-theme="bright"][data-palette="ivory"] body{
+    background: var(--bg-0) !important;
+    color: var(--txt-1) !important;
+}
+
+/* 3) 로그인 섹션(오른쪽) */
+html[data-theme="bright"][data-palette="ivory"] .auth{
+    background:
+            radial-gradient(1200px 600px at 60% -10%, rgba(255,255,255,.9) 0%, transparent 60%),
+            linear-gradient(180deg, #FFF8EA 0%, #FFF4DE 50%, #FFF0D4 100%) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .auth__card{
+    background: var(--surface) !important;
+    border: 1px solid var(--line-1) !important;
+    border-radius: 20px !important;
+    box-shadow:
+            0 1px 0 rgba(255,255,255,.85) inset,
+            0 8px 16px rgba(var(--shadow-rgb), .06),
+            0 28px 60px rgba(var(--shadow-rgb), .10) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .auth__title   { color: var(--txt-1) !important; }
+html[data-theme="bright"][data-palette="ivory"] .auth__sub     { color: var(--txt-2) !important; }
+html[data-theme="bright"][data-palette="ivory"] .auth__divider { color: color-mix(in srgb, var(--txt-2), #000 10%) !important; }
+html[data-theme="bright"][data-palette="ivory"] .auth__benefits{ color: color-mix(in srgb, var(--txt-2), #000 15%) !important; }
+html[data-theme="bright"][data-palette="ivory"] .auth__meta    { color: color-mix(in srgb, var(--txt-2), #000 5%) !important; }
+html[data-theme="bright"][data-palette="ivory"] .auth__meta a  { color: #5A64D6 !important; }
+
+/* 4) 메인(로그인 후) — 홈 히어로/윈도우/카드 */
+html[data-theme="bright"][data-palette="ivory"] .home-hero,
+html[data-theme="bright"][data-palette="ivory"] .mac-window{
+    background: var(--bg-1) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow: var(--shadow-1) !important;
+}
+
+html[data-theme="bright"][data-palette="ivory"] .mac-card{
+    background: var(--bg-2) !important;
+    border: 1px solid var(--line-1) !important;
+    color: var(--txt-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .mac-card.action.lg{
+    background: var(--bg-2) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow: 0 10px 26px rgba(var(--shadow-rgb), .10) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .mac-card.action.lg:hover{
+    transform: translateY(-2px);
+    background: var(--bg-2) !important;
+    border-color: color-mix(in srgb, var(--line-1), var(--primary-500) 20%) !important;
+    box-shadow: 0 14px 34px rgba(var(--shadow-rgb), .16),
+    0 0 0 3px color-mix(in srgb, var(--primary-500) 16%, transparent) !important;
+}
+
+/* 5) 카드 내부 텍스트/칩/아이콘 */
+html[data-theme="bright"][data-palette="ivory"] .card-title { color: var(--txt-1) !important; }
+html[data-theme="bright"][data-palette="ivory"] .card-sub   { color: var(--txt-2) !important; }
+
+html[data-theme="bright"][data-palette="ivory"] .chip{
+    background: var(--surface-2) !important;
+    border: 1px solid var(--line-1) !important;
+    color: var(--txt-2) !important;
+}
+
+html[data-theme="bright"][data-palette="ivory"] .card-icon{
+    background: var(--surface-2) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.25);
+}
+
+/* 6) 사이드바(라이트 톤 유지하되 아이보리 보더로) */
+html[data-theme="bright"][data-palette="ivory"] .mac-sidebar{
+    background: #FFF6E6 !important;
+    border-right: 1px solid var(--line-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .sidebar-item:hover{
+    background: #FFF2DA !important;
+    color: var(--txt-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .sidebar-item.active{
+    background: #FFEFD0 !important;
+    color: var(--txt-1) !important;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--line-1), var(--primary-500) 20%) !important;
+}
+
+/* 7) 악센트 호버 링(파스텔 농도) */
+html[data-theme="bright"][data-palette="ivory"] .mac-card.accent-violet:hover{ box-shadow:0 14px 34px rgba(var(--shadow-rgb), .14),0 0 0 4px rgba(139,108,246,.18) !important; }
+html[data-theme="bright"][data-palette="ivory"] .mac-card.accent-mint:hover  { box-shadow:0 14px 34px rgba(var(--shadow-rgb), .14),0 0 0 4px rgba(45,212,191,.18)  !important; }
+html[data-theme="bright"][data-palette="ivory"] .mac-card.accent-amber:hover { box-shadow:0 14px 34px rgba(var(--shadow-rgb), .14),0 0 0 4px rgba(244,161,26,.18)  !important; }
+html[data-theme="bright"][data-palette="ivory"] .mac-card.accent-pink:hover  { box-shadow:0 14px 34px rgba(var(--shadow-rgb), .14),0 0 0 4px rgba(236,72,153,.18)  !important; }
+html[data-theme="bright"][data-palette="ivory"] .mac-card.accent-blue:hover  { box-shadow:0 14px 34px rgba(var(--shadow-rgb), .14),0 0 0 4px rgba(96,165,250,.18)   !important; }
+html[data-theme="bright"][data-palette="ivory"] .mac-card.accent-lime:hover  { box-shadow:0 14px 34px rgba(var(--shadow-rgb), .14),0 0 0 4px rgba(132,204,22,.18)   !important; }
+
+/* 8) 페이지 공간 하이라이트도 아이보리 톤으로 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage::before{
+    background:
+            radial-gradient(800px 400px at 50% 120px, rgba(139,108,246,.05), transparent 60%),
+            radial-gradient(600px 600px at 60% 40%, rgba(255,200,120,.04), transparent 70%) !important;
+}
+/* =========================================================
+   IVORY → PORCELAIN (쿨 아이보리, 덜 노랗고 더 세련된 톤)
+   Paste at the VERY END of App.css
+========================================================= */
+
+/* 1) 팔레트: 채도/노랑기 낮춘 중립 톤 */
+html[data-theme="bright"][data-palette="ivory"]{
+    --bg:        #FAFAF7; /* page 배경: 거의 화이트에 살짝 베이지 */
+    --surface:   #FFFFFF; /* 카드/패널은 화이트로 깔끔 */
+    --surface-2: #F4F1EB; /* hover 살짝만 톤 차이 */
+    --border:    #ECE7DF; /* 경계선은 연한 토프 */
+
+    --text-strong:#141518; /* 제목: 완전 검정보다 한 톤 부드럽게 */
+    --text:       #1E1F22; /* 본문 */
+    --text-mute:  #6A6A63; /* 보조(회색기) */
+
+    /* 악센트 보라: 채도/명도 살짝 눌러서 과하지 않게 */
+    --primary-500:#7C6CF2;
+    --primary-600:#6E61E6;
+
+    --shadow-rgb: 22,18,12; /* 그림자 색도 살짝 중성화 */
+}
+
+/* 2) 전역 매핑 */
+html[data-theme="bright"][data-palette="ivory"]{
+    --bg-0: var(--bg);
+    --bg-1: var(--surface);
+    --bg-2: var(--surface);
+    --line-1: var(--border);
+    --txt-1: var(--text-strong);
+    --txt-2: var(--text-mute);
+}
+
+/* 3) 배경/컨테이너(가운데 까만 판 없애기) */
+html[data-theme="bright"][data-palette="ivory"] body,
+html[data-theme="bright"][data-palette="ivory"] #mainPage,
+html[data-theme="bright"][data-palette="ivory"] .mac-content,
+html[data-theme="bright"][data-palette="ivory"] .landing{
+    background: var(--bg-0) !important;
+    color: var(--txt-1) !important;
+}
+
+/* 4) 상단 바: 채도 낮춘 파스텔 */
+html[data-theme="bright"][data-palette="ivory"] .mac-titlebar{
+    background: linear-gradient(90deg, #EDECF9, #EAF2FF);
+    border-bottom: 1px solid var(--line-1);
+    box-shadow: 0 6px 18px rgba(var(--shadow-rgb), .06);
+    color: var(--txt-1);
+}
+
+/* 5) 패널/카드(화이트 베이스 + 얕은 그림자) */
+html[data-theme="bright"][data-palette="ivory"] .home-hero,
+html[data-theme="bright"][data-palette="ivory"] .mac-window{
+    background: var(--bg-1) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow:
+            0 1px 0 rgba(255,255,255,.8) inset,
+            0 8px 16px rgba(var(--shadow-rgb), .06),
+            0 20px 48px rgba(var(--shadow-rgb), .08) !important;
+}
+
+/* 6) 기능 카드 */
+html[data-theme="bright"][data-palette="ivory"] .mac-card,
+html[data-theme="bright"][data-palette="ivory"] .mac-card.action.lg{
+    background: var(--bg-2) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow: 0 8px 18px rgba(var(--shadow-rgb), .06) !important;
+    color: var(--txt-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .mac-card.action.lg:hover{
+    transform: translateY(-2px);
+    background: var(--bg-2) !important;
+    border-color: color-mix(in srgb, var(--line-1), var(--primary-500) 18%) !important;
+    box-shadow: 0 14px 28px rgba(var(--shadow-rgb), .10),
+    0 0 0 3px color-mix(in srgb, var(--primary-500) 14%, transparent) !important;
+}
+
+/* 7) 카드 내부 톤 */
+html[data-theme="bright"][data-palette="ivory"] .card-title{ color: var(--txt-1) !important; }
+html[data-theme="bright"][data-palette="ivory"] .card-sub  { color: var(--txt-2) !important; }
+html[data-theme="bright"][data-palette="ivory"] .card-icon {
+    background: var(--surface-2) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.25);
+}
+
+/* 8) 칩/사이드바 */
+html[data-theme="bright"][data-palette="ivory"] .chip{
+    background: var(--surface-2) !important;
+    border: 1px solid var(--line-1) !important;
+    color: var(--txt-2) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .mac-sidebar{
+    background: #F9F7F1 !important;
+    border-right: 1px solid var(--line-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .sidebar-item:hover{
+    background: #F4F1EB !important; color: var(--txt-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] .sidebar-item.active{
+    background: #EEE9E0 !important; color: var(--txt-1) !important;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--line-1), var(--primary-500) 18%) !important;
+}
+
+/* 9) 페이지 하이라이트(보라/파랑 글로우 제거 → 중립) */
+html[data-theme="bright"][data-palette="ivory"] #mainPage::before{
+    background:
+            radial-gradient(800px 400px at 50% 120px, rgba(0,0,0,.02), transparent 60%) !important;
+}
+/* =========================================================
+   MONO UNDER TITLEBAR — Neutral, bright, minimal
+   (paste at the VERY END of App.css)
+========================================================= */
+
+/* 메인 영역 전용 중립 토큰 주입 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage{
+    --bg-0:#F7F8FA;   /* 페이지 바탕 (쿨 그레이) */
+    --bg-1:#FFFFFF;   /* 패널/카드 */
+    --bg-2:#FFFFFF;   /* 카드 */
+    --line-1:#E7EAF0; /* 매우 연한 그레이 보더 */
+    --txt-1:#0B1220;  /* 제목/본문 */
+    --txt-2:#667085;  /* 보조 텍스트 */
+    --shadow-1:0 10px 24px rgba(16,24,40,.08);
+}
+
+/* 페이지 바탕을 중립으로 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage,
+html[data-theme="bright"][data-palette="ivory"] .mac-content{
+    background: var(--bg-0) !important;
+    color: var(--txt-1) !important;
+}
+
+/* 패널/카드(무채색 화이트 + 아주 얕은 그림자) */
+html[data-theme="bright"][data-palette="ivory"] #mainPage .home-hero,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .mac-window{
+    background: var(--bg-1) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow:
+            0 1px 0 rgba(255,255,255,.85) inset,
+            0 8px 16px rgba(16,24,40,.06),
+            0 20px 44px rgba(16,24,40,.08) !important;
+}
+
+html[data-theme="bright"][data-palette="ivory"] #mainPage .mac-card,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .mac-card.action.lg{
+    background: var(--bg-2) !important;
+    border: 1px solid var(--line-1) !important;
+    box-shadow: 0 8px 18px rgba(16,24,40,.06) !important;
+    color: var(--txt-1) !important;
+}
+html[data-theme="bright"][data-palette="ivory"] #mainPage .mac-card.action.lg:hover{
+    transform: translateY(-2px);
+    background: var(--bg-2) !important;
+    border-color: color-mix(in srgb, var(--line-1), #8B5CF6 16%) !important; /* 은은한 링 */
+    box-shadow: 0 14px 28px rgba(16,24,40,.10),
+    0 0 0 3px color-mix(in srgb, #8B5CF6 12%, transparent) !important;
+}
+
+/* 카드 내부 톤(완전 무채색) */
+html[data-theme="bright"][data-palette="ivory"] #mainPage .card-title{ color: var(--txt-1) !important; }
+html[data-theme="bright"][data-palette="ivory"] #mainPage .card-sub  { color: var(--txt-2) !important; }
+html[data-theme="bright"][data-palette="ivory"] #mainPage .card-icon{
+    background:#F3F4F6 !important;
+    border:1px solid var(--line-1) !important;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.25);
+}
+
+/* 칩/사이드 요소도 무채색화 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage .chip{
+    background:#F3F4F6 !important;
+    border:1px solid var(--line-1) !important;
+    color: var(--txt-2) !important;
+}
+
+/* 배경 하이라이트(보라/주황 글로우) 제거 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage::before{ content:none !important; }
+/* =========================================================
+   READABILITY PATCH — bright/mono에서 흐린 글씨 살리기
+   (Paste at the VERY END of App.css)
+========================================================= */
+
+/* 섹션/패널 헤더 글자: 완전 불투명 + 중립 텍스트 컬러 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage h1,
+html[data-theme="bright"][data-palette="ivory"] #mainPage h2,
+html[data-theme="bright"][data-palette="ivory"] #mainPage h3,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .section-head h3,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .section-title,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .mac-window > h2{
+    color: var(--txt-1) !important;
+    opacity: 1 !important;
+    text-shadow: none !important;
+}
+
+/* 작은 라벨/부제/메타 텍스트(‘빠른 작업’ 주변, 카드 부제 등) */
+html[data-theme="bright"][data-palette="ivory"] #mainPage .label,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .subtle,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .meta,
+html[data-theme="bright"][data-palette="ivory"] #mainPage .card-sub{
+    color: var(--txt-2) !important;
+    opacity: .95 !important;  /* 너무 흐리지 않게 */
+    text-shadow: none !important;
+}
+
+/* 패널 상단 보더도 밝은 톤으로 통일 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage .mac-window > h2{
+    border-bottom: 1px solid var(--line-1) !important;
+}
+
+/* 혹시 남아있는 흰색 고정 스타일을 무력화 */
+html[data-theme="bright"][data-palette="ivory"] #mainPage [style*="color:#fff"],
+html[data-theme="bright"][data-palette="ivory"] #mainPage [style*="color: #fff"]{
+    color: var(--txt-1) !important;
+}
+
+
 
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,375 +1,496 @@
 import "./App.css";
-import React, { useState, useRef, useEffect } from 'react';
+import './bright.css';
+import React, { useState, useRef, useEffect } from "react";
 
-const SECTION_LIST = [
-  'main', 'drive', 'portal', 'pptMaker', 'myPage'
-];
+function FeatureCard({ emoji, icon, title, subtitle, onClick, accent = "violet" }) {
+    return (
+        <button className={`mac-card action lg accent-${accent}`} onClick={onClick}>
+            <div className="card-row">
+                <div className="card-icon">
+                    {emoji ? <span className="card-emoji" role="img" aria-label={title}>{emoji}</span>
+                        : <i className={icon}></i>}
+                </div>
+                <div className="card-text">
+                    <div className="card-title">{title}</div>
+                    <div className="card-sub">{subtitle}</div>
+                </div>
+            </div>
+        </button>
+    );
+}
 
 function App() {
-  // 상태 관리
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [activeSection, setActiveSection] = useState('main');
-  const [showModal, setShowModal] = useState(false);
-  const [experiences, setExperiences] = useState([]);
-  const [form, setForm] = useState({ title: '', period: '', description: '' });
-  const [selected, setSelected] = useState([]);
-  const formRef = useRef();
-    // 추가: 테마/팔레트 상태
-    const [theme, setTheme] = useState('dark');      // 'dark' | 'light'
-    const [palette, setPalette] = useState('aurora'); // 'aurora' | 'plum' | 'sunset'
+    // 상태 관리
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [activeSection, setActiveSection] = useState("main");
+    const [showModal, setShowModal] = useState(false);
+    const [experiences, setExperiences] = useState([]);
+    const [form, setForm] = useState({ title: "", period: "", description: "" });
+    const [selected, setSelected] = useState([]);
+    const formRef = useRef();
 
-// 루트 html에 data-속성으로 반영
+    // 테마/팔레트
+    const [theme, setTheme] = useState("dark");       // 'dark' | 'light'
+    const [palette, setPalette] = useState("aurora"); // 'aurora' | 'plum' | 'sunset'
+
+    // html data-* 적용
     useEffect(() => {
         const root = document.documentElement;
-        root.setAttribute('data-theme', theme);
-        root.setAttribute('data-palette', palette);
+        root.setAttribute("data-theme", theme);
+        root.setAttribute("data-palette", palette);
     }, [theme, palette]);
 
-
     // 섹션 전환
-  function showSection(section) {
-    setActiveSection(section);
-  }
-
-  // 로그인 (구글 로그인 콜백 시 호출)
-  function handleCredentialResponse(response) {
-    setIsLoggedIn(true);
-    setActiveSection('main');
-  }
-
-  // 로그아웃
-  function logout() {
-    if (window.confirm('로그아웃 하시겠습니까?')) {
-      setIsLoggedIn(false);
-      setActiveSection('main');
+    function showSection(section) {
+        setActiveSection(section);
     }
-  }
 
-  // 이력 추가 모달
-  function showAddExperienceModal() {
-    setShowModal(true);
-  }
-  function closeModal() {
-    setShowModal(false);
-    setForm({ title: '', period: '', description: '' });
-  }
-
-  // 이력 저장
-  function saveExperience(e) {
-    e.preventDefault();
-    if (form.title && form.period && form.description) {
-      setExperiences([...experiences, { ...form }]);
-      closeModal();
+    // 로그인 (구글 GSI 콜백)
+    function handleCredentialResponse() {
+        setIsLoggedIn(true);
+        setActiveSection("main");
     }
-  }
 
-  // 전체 선택/해제
-  function selectAllExperiences(select) {
-    if (select) {
-      setSelected(experiences.map((_, i) => i));
-    } else {
-      setSelected([]);
-    }
-  }
-
-  // 체크박스 변경
-  function toggleSelect(idx) {
-    setSelected(selected.includes(idx)
-      ? selected.filter(i => i !== idx)
-      : [...selected, idx]
-    );
-  }
-
-  // 구글 로그인 버튼 렌더링 (GSI 위젯)
-  useEffect(() => {
-    if (!isLoggedIn) {
-      // GSI 스크립트 동적 로드
-      const script = document.createElement('script');
-      script.src = 'https://accounts.google.com/gsi/client';
-      script.async = true;
-      script.defer = true;
-      document.body.appendChild(script);
-      script.onload = () => {
-        if (window.google && window.google.accounts && window.google.accounts.id) {
-          window.google.accounts.id.initialize({
-            client_id: '315917737558-2qd5q4as4qbh03vru788h5ccrci9bbed.apps.googleusercontent.com',
-            callback: handleCredentialResponse,
-            auto_select: false,
-          });
-          window.google.accounts.id.renderButton(
-            document.getElementById('googleSignInDiv'),
-            { theme: 'outline', size: 'large', width: 300 }
-          );
+    // 로그아웃
+    function logout() {
+        if (window.confirm("로그아웃 하시겠습니까?")) {
+            setIsLoggedIn(false);
+            setActiveSection("main");
         }
-      };
-      return () => {
-        document.body.removeChild(script);
-      };
     }
-  }, [isLoggedIn]);
 
-  // 실제 화면 렌더링
-  return (
-    <div>
-      {/* 로그인 페이지 */}
-        {!isLoggedIn && (
-            <main className="landing">
-                {/* 왼쪽 */}
-                <section className="hero">
-                    <div className="hero__wrap">
-                        <h1 className="hero__logo">Portra</h1>
-                        <p className="hero__lead">3분 만에 완성하는 AI 포트폴리오</p>
-                        <ul className="hero__features">
-                            <li>간편한 이력 관리</li>
-                            <li>전문적인 PPT 템플릿</li>
-                            <li>구글 드라이브 연동</li>
-                        </ul>
-                    </div>
-                </section>
+    // 이력 모달
+    function showAddExperienceModal() {
+        setShowModal(true);
+    }
+    function closeModal() {
+        setShowModal(false);
+        setForm({ title: "", period: "", description: "" });
+    }
 
-                {/* 오른쪽 */}
-                <section className="auth">
-                    <div className="auth__card auth__card--elev">
-                        <header className="auth__head">
-                            <h2 className="auth__title">시작하기</h2>
-                            <p className="auth__sub">Google로 로그인하여 Portra를 바로 사용해 보세요</p>
-                        </header>
+    // 이력 저장
+    function saveExperience(e) {
+        e.preventDefault();
+        if (form.title && form.period && form.description) {
+            setExperiences([...experiences, { ...form }]);
+            closeModal();
+        }
+    }
 
-                        <div className="auth__actions">
-                            <div id="googleSignInDiv" className="auth__google"></div>
+    // 전체 선택/해제
+    function selectAllExperiences(select) {
+        if (select) setSelected(experiences.map((_, i) => i));
+        else setSelected([]);
+    }
+
+    // 체크박스 토글
+    function toggleSelect(idx) {
+        setSelected(
+            selected.includes(idx)
+                ? selected.filter((i) => i !== idx)
+                : [...selected, idx]
+        );
+    }
+
+    // 구글 로그인 버튼 렌더링 (GSI)
+    useEffect(() => {
+        if (!isLoggedIn) {
+            const script = document.createElement("script");
+            script.src = "https://accounts.google.com/gsi/client";
+            script.async = true;
+            script.defer = true;
+            document.body.appendChild(script);
+            script.onload = () => {
+                if (window.google?.accounts?.id) {
+                    window.google.accounts.id.initialize({
+                        client_id:
+                            "315917737558-2qd5q4as4qbh03vru788h5ccrci9bbed.apps.googleusercontent.com",
+                        callback: handleCredentialResponse,
+                        auto_select: false,
+                    });
+                    window.google.accounts.id.renderButton(
+                        document.getElementById("googleSignInDiv"),
+                        { theme: "outline", size: "large", width: 300 }
+                    );
+                }
+            };
+            return () => document.body.removeChild(script);
+        }
+    }, [isLoggedIn]);
+
+    // 화면
+    return (
+        <div>
+            {/* 로그인 전 랜딩 */}
+            {!isLoggedIn && (
+                <main className="landing">
+                    {/* 왼쪽 Hero */}
+                    <section className="hero">
+                        <div className="hero__wrap">
+                            <h1 className="hero__logo">Portra</h1>
+                            <p className="hero__lead">3분 만에 완성하는 AI 포트폴리오</p>
+                            <ul className="hero__features">
+                                <li>간편한 이력 관리</li>
+                                <li>전문적인 PPT 템플릿</li>
+                                <li>구글 드라이브 연동</li>
+                            </ul>
                         </div>
+                    </section>
 
-                        <div className="auth__divider"><span>또는</span></div>
+                    {/* 오른쪽 Auth */}
+                    <section className="auth">
+                        <div className="auth__card auth__card--elev">
+                            <header className="auth__head">
+                                <h2 className="auth__title">시작하기</h2>
+                                <p className="auth__sub">
+                                    Google로 로그인하여 Portra를 바로 사용해 보세요
+                                </p>
+                            </header>
 
-                        <ul className="auth__benefits">
-                            <li>회원가입 없이 10초만에 시작</li>
-                            <li>언제든지 로그아웃 및 데이터 삭제 가능</li>
-                        </ul>
+                            <div className="auth__actions">
+                                <div id="googleSignInDiv" className="auth__google"></div>
+                            </div>
 
-                        <p className="auth__meta">
-                            계속 진행하면 <a href="#">서비스 약관</a> 및 <a href="#">개인정보 처리방침</a>에 동의하게 됩니다.
-                        </p>
+                            <div className="auth__divider">
+                                <span>또는</span>
+                            </div>
+
+                            <ul className="auth__benefits">
+                                <li>회원가입 없이 10초만에 시작</li>
+                                <li>언제든지 로그아웃 및 데이터 삭제 가능</li>
+                            </ul>
+
+                            <p className="auth__meta">
+                                계속 진행하면 <a href="#">서비스 약관</a> 및{" "}
+                                <a href="#">개인정보 처리방침</a>에 동의하게 됩니다.
+                            </p>
+                        </div>
+                    </section>
+                </main>
+            )}
+
+            {/* 로그인 후 메인 */}
+            {isLoggedIn && (
+                <div id="mainPage">
+                    <div className="mac-titlebar">
+                        <div className="mac-title">Portra</div>
                     </div>
-                </section>
-            </main>
-        )}
 
-        {/* 메인 페이지 */}
-      {isLoggedIn && (
-        <div id="mainPage">
-          <div className="mac-titlebar">
-            <div className="mac-title">Portra</div>
-          </div>
-          <div className="mac-container">
-            <div className="mac-sidebar">
-              {SECTION_LIST.map(section => (
+                    {/* ★ 사이드바 제거한 단일 레이아웃 */}
+                    <div className="mac-container no-sidebar">
+                        <div className="mac-content mac-content--padded">
+                            {/* 메인이 아닌 화면에서는 상단에 ‘메인으로’ 버튼 */}
+                            {activeSection !== "main" && (
+                                <div className="top-actions" style={{ marginBottom: 12 }}>
+                                    <button
+                                        className="btn btn-outline-dark btn-sm"
+                                        onClick={() => setActiveSection("main")}
+                                    >
+                                        ← 메인으로
+                                    </button>
+                                </div>
+                            )}
+
+                            {/* 메인 카드 6개 */}
+                            {activeSection === "main" && (
+                                <div id="mainSection" className="content-section">
+
+                                    {/* 컴팩트 히어로 바 */}
+                                    <div className="home-hero">
+                                        <div>
+                                            <h2>무엇을 할까요?</h2>
+                                            <p>아래 카드에서 원하는 작업을 선택하세요.</p>
+                                        </div>
+                                        <div className="chips">
+                                            <span className="chip">최근 0</span>
+                                            <span className="chip">이력 {experiences.length}</span>
+                                            <span className="chip">템플릿 4</span>
+                                        </div>
+                                    </div>
+
+                                    {/* 패널 안에 3×2 그리드 */}
+                                    <div className="mac-window">
+                                        <div className="mac-window-content">
+                                            <div className="section-head">
+                                                <h3>빠른 작업</h3>
+                                            </div>
+
+                                            <div className="cards-6 big">
+                                                <FeatureCard
+                                                    emoji="🏠" accent="violet"
+                                                    title="메인페이지" subtitle="시작 화면으로 이동"
+                                                    onClick={() => setActiveSection("main")}
+                                                />
+                                                <FeatureCard
+                                                    emoji="🟩" accent="mint"
+                                                    title="구글 드라이브" subtitle="파일 불러오기"
+                                                    onClick={() => showSection("drive")}
+                                                />
+                                                <FeatureCard
+                                                    emoji="🏫" accent="amber"
+                                                    title="학교 포털" subtitle="학사 정보 확인"
+                                                    onClick={() => showSection("portal")}
+                                                />
+                                                <FeatureCard
+                                                    emoji="📑" accent="pink"
+                                                    title="PPT 제작" subtitle="포트폴리오 만들기"
+                                                    onClick={() => showSection("pptMaker")}
+                                                />
+                                                <FeatureCard
+                                                    emoji="👤" accent="blue"
+                                                    title="마이페이지" subtitle="이력/기록 관리"
+                                                    onClick={() => showSection("myPage")}
+                                                />
+                                                <FeatureCard
+                                                    emoji="➕" accent="lime"
+                                                    title="이력 등록" subtitle="새로운 경험을 추가"
+                                                    onClick={showAddExperienceModal}
+                                                />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* PPT 제작 섹션 */}
+                            {activeSection === "pptMaker" && (
+                                <div id="pptMakerSection" className="content-section">
+                                    <div className="mac-window">
+                                        <h2>포트폴리오 내용 선택</h2>
+                                        <div className="mac-window-content">
+                                            <div className="d-flex justify-content-between align-items-center mb-3">
+                                                <div>
+                                                    <button
+                                                        className="btn btn-outline-dark me-2"
+                                                        onClick={() => selectAllExperiences(true)}
+                                                    >
+                                                        전체 선택
+                                                    </button>
+                                                    <button
+                                                        className="btn btn-outline-dark"
+                                                        onClick={() => selectAllExperiences(false)}
+                                                    >
+                                                        전체 해제
+                                                    </button>
+                                                </div>
+                                                <button
+                                                    className="btn btn-dark"
+                                                    id="nextButton"
+                                                    disabled={selected.length === 0}
+                                                >
+                                                    다음
+                                                </button>
+                                            </div>
+                                            <div id="experienceList" className="mac-list">
+                                                {experiences.length === 0 ? (
+                                                    <div className="empty-state">
+                                                        <i className="fas fa-clipboard-list fa-3x mb-3"></i>
+                                                        <p>등록된 이력이 없습니다.</p>
+                                                    </div>
+                                                ) : (
+                                                    experiences.map((exp, idx) => (
+                                                        <div className="list-group-item" key={idx}>
+                                                            <div className="d-flex align-items-center">
+                                                                <div className="flex-grow-1">
+                                                                    <h6 className="mb-1">{exp.title}</h6>
+                                                                    <p className="mb-1">
+                                                                        <small>{exp.period}</small>
+                                                                    </p>
+                                                                    <p className="mb-0">{exp.description}</p>
+                                                                </div>
+                                                                <div className="form-check ms-3">
+                                                                    <input
+                                                                        className="form-check-input"
+                                                                        type="checkbox"
+                                                                        checked={selected.includes(idx)}
+                                                                        onChange={() => toggleSelect(idx)}
+                                                                    />
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    ))
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* 구글 드라이브 섹션 */}
+                            {activeSection === "drive" && (
+                                <div id="driveSection" className="content-section">
+                                    <div className="mac-window">
+                                        <h2>구글 드라이브</h2>
+                                        <div className="mac-window-content text-center p-5">
+                                            <i className="fab fa-google-drive fa-3x mb-3 text-primary"></i>
+                                            <h3 className="mb-3">구글 드라이브로 이동</h3>
+                                            <p className="mb-4">구글 드라이브에서 파일을 관리하세요.</p>
+                                            <a
+                                                href="https://drive.google.com"
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="btn btn-primary"
+                                            >
+                                                구글 드라이브 열기
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* 학교 포털 섹션 */}
+                            {activeSection === "portal" && (
+                                <div id="portalSection" className="content-section">
+                                    <div className="mac-window">
+                                        <h2>학교 포털</h2>
+                                        <div className="mac-window-content text-center p-5">
+                                            <i className="fas fa-university fa-3x mb-3 text-primary"></i>
+                                            <h3 className="mb-3">학교 포털로 이동</h3>
+                                            <p className="mb-4">학교 포털에서 학사 정보를 확인하세요.</p>
+                                            <a href="#" className="btn btn-primary">
+                                                학교 포털 열기
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* 마이페이지 섹션 */}
+                            {activeSection === "myPage" && (
+                                <div id="myPageSection" className="content-section">
+                                    <div className="mac-grid">
+                                        <div className="mac-window">
+                                            <h2>PPT 기록</h2>
+                                            <div id="pptHistory" className="mac-list">
+                                                <div className="empty-state">
+                                                    <i className="fas fa-history fa-3x mb-3"></i>
+                                                    <p>아직 제작한 PPT가 없습니다.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div className="mac-window">
+                                            <h2>이력 관리</h2>
+                                            <div id="experienceManagement" className="mac-list">
+                                                {experiences.length === 0 ? (
+                                                    <div className="empty-state">
+                                                        <i className="fas fa-clipboard-list fa-3x mb-3"></i>
+                                                        <p>등록된 이력이 없습니다.</p>
+                                                    </div>
+                                                ) : (
+                                                    experiences.map((exp, idx) => (
+                                                        <div className="list-group-item" key={idx}>
+                                                            <div className="d-flex align-items-center">
+                                                                <div className="flex-grow-1">
+                                                                    <h6 className="mb-1">{exp.title}</h6>
+                                                                    <p className="mb-0">
+                                                                        <small>{exp.period}</small>
+                                                                    </p>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    ))
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* 스타일 스위처(고정 위치) */}
+                    <div className="style-switcher">
+                        <button
+                            className="sw-btn"
+                            onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
+                        >
+                            {theme === "dark" ? "🌙" : "☀︎"}
+                        </button>
+
+                        <div className="sw-pals">
+                            <button
+                                className={`sw-dot sw-dot--aurora ${palette === "aurora" ? "is-active" : ""}`}
+                                title="Aurora"
+                                onClick={() => setPalette("aurora")}
+                            />
+                            <button
+                                className={`sw-dot sw-dot--plum ${palette === "plum" ? "is-active" : ""}`}
+                                title="Plum"
+                                onClick={() => setPalette("plum")}
+                            />
+                            <button
+                                className={`sw-dot sw-dot--sunset ${palette === "sunset" ? "is-active" : ""}`}
+                                title="Sunset"
+                                onClick={() => setPalette("sunset")}
+                            />
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 이력 추가 모달 */}
+            {showModal && (
                 <div
-                  key={section}
-                  className={`sidebar-item${activeSection === section ? ' active' : ''}${section === 'myPage' ? '' : ''}`}
-                  onClick={() => showSection(section)}
+                    className="modal fade show"
+                    style={{ display: "block", background: "rgba(0,0,0,0.5)" }}
+                    tabIndex="-1"
                 >
-                  {section === 'main' && (<><i className="fas fa-home"></i> <span>메인페이지</span></>)}
-                  {section === 'drive' && (<><i className="fab fa-google-drive"></i> <span>구글 드라이브</span></>)}
-                  {section === 'portal' && (<><i className="fas fa-university"></i> <span>학교 포털</span></>)}
-                  {section === 'pptMaker' && (<><i className="fas fa-file-powerpoint"></i> <span>PPT 제작</span></>)}
-                  {section === 'myPage' && (<><i className="fas fa-user"></i> <span>마이페이지</span></>)}
-                </div>
-              ))}
-                {/* 스타일 스위처 (개발용) */}
-                {/* 스타일 스위처 (개발용) */}
-                <div className="style-switcher">
-                    <button className="sw-btn" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
-                        {theme === 'dark' ? '🌙' : '☀︎'}
-                    </button>
-
-                    <div className="sw-pals">
-                        <button
-                            className={`sw-dot sw-dot--aurora ${palette==='aurora' ? 'is-active' : ''}`}
-                            title="Aurora"
-                            onClick={() => setPalette('aurora')}
-                        />
-                        <button
-                            className={`sw-dot sw-dot--plum ${palette==='plum' ? 'is-active' : ''}`}
-                            title="Plum"
-                            onClick={() => setPalette('plum')}
-                        />
-                        <button
-                            className={`sw-dot sw-dot--sunset ${palette==='sunset' ? 'is-active' : ''}`}
-                            title="Sunset"
-                            onClick={() => setPalette('sunset')}
-                        />
-                    </div>
-                </div>
-
-                <div className="sidebar-item mt-auto" onClick={logout}>
-                <i className="fas fa-sign-out-alt"></i>
-                <span>로그아웃</span>
-              </div>
-            </div>
-            <div className="mac-content">
-              {/* 메인 섹션 */}
-              {activeSection === 'main' && (
-                <div id="mainSection" className="content-section">
-                  <div className="mac-grid">
-                    <div className="mac-card" onClick={showAddExperienceModal}>
-                      <i className="fas fa-plus-circle"></i>
-                      <h3>이력 등록</h3>
-                      <p>새로운 경험을 추가하세요</p>
-                    </div>
-                    <div className="mac-card" onClick={() => showSection('pptMaker')}>
-                      <i className="fas fa-file-powerpoint"></i>
-                      <h3>PPT 제작</h3>
-                      <p>포트폴리오 만들기</p>
-                    </div>
-                  </div>
-                </div>
-              )}
-              {/* PPT 제작 섹션 */}
-              {activeSection === 'pptMaker' && (
-                <div id="pptMakerSection" className="content-section">
-                  <div className="mac-window">
-                    <h2>포트폴리오 내용 선택</h2>
-                    <div className="mac-window-content">
-                      <div className="d-flex justify-content-between align-items-center mb-3">
-                        <div>
-                          <button className="btn btn-outline-dark me-2" onClick={() => selectAllExperiences(true)}>전체 선택</button>
-                          <button className="btn btn-outline-dark" onClick={() => selectAllExperiences(false)}>전체 해제</button>
-                        </div>
-                        <button className="btn btn-dark" id="nextButton" disabled={selected.length === 0}>다음</button>
-                      </div>
-                      <div id="experienceList" className="mac-list">
-                        {experiences.length === 0 ? (
-                          <div className="empty-state">
-                            <i className="fas fa-clipboard-list fa-3x mb-3"></i>
-                            <p>등록된 이력이 없습니다.</p>
-                          </div>
-                        ) : (
-                          experiences.map((exp, idx) => (
-                            <div className="list-group-item" key={idx}>
-                              <div className="d-flex align-items-center">
-                                <div className="flex-grow-1">
-                                  <h6 className="mb-1">{exp.title}</h6>
-                                  <p className="mb-1"><small>{exp.period}</small></p>
-                                  <p className="mb-0">{exp.description}</p>
-                                </div>
-                                <div className="form-check ms-3">
-                                  <input className="form-check-input" type="checkbox" checked={selected.includes(idx)} onChange={() => toggleSelect(idx)} />
-                                </div>
-                              </div>
+                    <div className="modal-dialog modal-dialog-centered">
+                        <div className="modal-content mac-modal">
+                            <div className="modal-header">
+                                <h5 className="modal-title">새 이력 추가</h5>
+                                <button type="button" className="btn-close" onClick={closeModal}></button>
                             </div>
-                          ))
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-              {/* 구글 드라이브 섹션 */}
-              {activeSection === 'drive' && (
-                <div id="driveSection" className="content-section">
-                  <div className="mac-window">
-                    <h2>구글 드라이브</h2>
-                    <div className="mac-window-content text-center p-5">
-                      <i className="fab fa-google-drive fa-3x mb-3 text-primary"></i>
-                      <h3 className="mb-3">구글 드라이브로 이동</h3>
-                      <p className="mb-4">구글 드라이브에서 파일을 관리하세요.</p>
-                      <a href="https://drive.google.com" target="_blank" className="btn btn-primary">구글 드라이브 열기</a>
-                    </div>
-                  </div>
-                </div>
-              )}
-              {/* 학교 포털 섹션 */}
-              {activeSection === 'portal' && (
-                <div id="portalSection" className="content-section">
-                  <div className="mac-window">
-                    <h2>학교 포털</h2>
-                    <div className="mac-window-content text-center p-5">
-                      <i className="fas fa-university fa-3x mb-3 text-primary"></i>
-                      <h3 className="mb-3">학교 포털로 이동</h3>
-                      <p className="mb-4">학교 포털에서 학사 정보를 확인하세요.</p>
-                      <a href="#" className="btn btn-primary">학교 포털 열기</a>
-                    </div>
-                  </div>
-                </div>
-              )}
-              {/* 마이페이지 섹션 */}
-              {activeSection === 'myPage' && (
-                <div id="myPageSection" className="content-section">
-                  <div className="mac-grid">
-                    <div className="mac-window">
-                      <h2>PPT 기록</h2>
-                      <div id="pptHistory" className="mac-list">
-                        <div className="empty-state">
-                          <i className="fas fa-history fa-3x mb-3"></i>
-                          <p>아직 제작한 PPT가 없습니다.</p>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="mac-window">
-                      <h2>이력 관리</h2>
-                      <div id="experienceManagement" className="mac-list">
-                        {experiences.length === 0 ? (
-                          <div className="empty-state">
-                            <i className="fas fa-clipboard-list fa-3x mb-3"></i>
-                            <p>등록된 이력이 없습니다.</p>
-                          </div>
-                        ) : (
-                          experiences.map((exp, idx) => (
-                            <div className="list-group-item" key={idx}>
-                              <div className="d-flex align-items-center">
-                                <div className="flex-grow-1">
-                                  <h6 className="mb-1">{exp.title}</h6>
-                                  <p className="mb-0"><small>{exp.period}</small></p>
+                            <form onSubmit={saveExperience} ref={formRef}>
+                                <div className="modal-body">
+                                    <div className="mb-3">
+                                        <label className="form-label">제목</label>
+                                        <input
+                                            type="text"
+                                            className="form-control"
+                                            required
+                                            value={form.title}
+                                            onChange={(e) => setForm({ ...form, title: e.target.value })}
+                                        />
+                                    </div>
+                                    <div className="mb-3">
+                                        <label className="form-label">기간</label>
+                                        <input
+                                            type="text"
+                                            className="form-control"
+                                            placeholder="예: 2023.03 - 2023.12"
+                                            required
+                                            value={form.period}
+                                            onChange={(e) => setForm({ ...form, period: e.target.value })}
+                                        />
+                                    </div>
+                                    <div className="mb-3">
+                                        <label className="form-label">설명</label>
+                                        <textarea
+                                            className="form-control"
+                                            rows="3"
+                                            required
+                                            value={form.description}
+                                            onChange={(e) => setForm({ ...form, description: e.target.value })}
+                                        ></textarea>
+                                    </div>
                                 </div>
-                              </div>
-                            </div>
-                          ))
-                        )}
-                      </div>
+                                <div className="modal-footer">
+                                    <button type="button" className="btn btn-secondary" onClick={closeModal}>
+                                        취소
+                                    </button>
+                                    <button type="submit" className="btn btn-primary">
+                                        저장
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
                     </div>
-                  </div>
                 </div>
-              )}
-            </div>
-          </div>
+            )}
         </div>
-      )}
-
-      {/* 이력 추가 모달 */}
-      {showModal && (
-        <div className="modal fade show" style={{ display: 'block', background: 'rgba(0,0,0,0.5)' }} tabIndex="-1">
-          <div className="modal-dialog modal-dialog-centered">
-            <div className="modal-content mac-modal">
-              <div className="modal-header">
-                <h5 className="modal-title">새 이력 추가</h5>
-                <button type="button" className="btn-close" onClick={closeModal}></button>
-              </div>
-              <form onSubmit={saveExperience} ref={formRef}>
-                <div className="modal-body">
-                  <div className="mb-3">
-                    <label className="form-label">제목</label>
-                    <input type="text" className="form-control" required value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} />
-                  </div>
-                  <div className="mb-3">
-                    <label className="form-label">기간</label>
-                    <input type="text" className="form-control" placeholder="예: 2023.03 - 2023.12" required value={form.period} onChange={e => setForm({ ...form, period: e.target.value })} />
-                  </div>
-                  <div className="mb-3">
-                    <label className="form-label">설명</label>
-                    <textarea className="form-control" rows="3" required value={form.description} onChange={e => setForm({ ...form, description: e.target.value })}></textarea>
-                  </div>
-                </div>
-                <div className="modal-footer">
-                  <button type="button" className="btn btn-secondary" onClick={closeModal}>취소</button>
-                  <button type="submit" className="btn btn-primary">저장</button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+    );
 }
 
 export default App;

--- a/src/bright.css
+++ b/src/bright.css
@@ -1,0 +1,21 @@
+/* src/bright.css */
+html[data-theme="bright"]{
+    --bg-0:#F7FAFF; --bg-1:#FFFFFF; --bg-2:#FFFFFF;
+    --line-1:#E8EDF8; --txt-1:#0B1220; --txt-2:#5B6476;
+}
+
+/* 핵심 배경만 강제 */
+html[data-theme="bright"] body{
+    background:var(--bg-0) !important;
+    color:var(--txt-1) !important;
+}
+html[data-theme="bright"] .auth{
+    background:linear-gradient(180deg,#EEF3FF, #E7ECFA) !important;
+}
+html[data-theme="bright"] .home-hero,
+html[data-theme="bright"] .mac-window,
+html[data-theme="bright"] .mac-card.action.lg{
+    background:var(--bg-1) !important;
+    border:1px solid var(--line-1) !important;
+    box-shadow:0 12px 28px rgba(15,23,42,.10) !important;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 import './styles.css';
+import './bright.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import 'bootstrap/dist/css/bootstrap.min.css';
+
+document.documentElement.setAttribute('data-theme', 'bright');
+document.documentElement.setAttribute('data-palette', 'aurora');
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## 개요
- 랜딩 우측(로그인 영역) 그레이 톤 적용
- 카드 글래스/그림자, 타이포 가독성, 버튼 충돌 보정

## 주요 변경
- `App.css`
  - 우측 배경을 중성 그레이 팔레트로 통일
  - `.auth__card` 음영/경계/배경(라이트 그레이) 폴리싱
  - Google 버튼 주위 그림자/테두리 충돌 보정
  - 좌/우 시각 단절 최소화를 위한 가장자리 페이드
- `index.html`
  - SUIT 웹폰트 preconnect/stylesheet 추가 (텍스트 렌더링 개선)

## 왜?
- 좌/우가 따로 노는 느낌 최소화
- 밝은 회색 톤에서 텍스트 대비/선명도 향상
- 카드가 과하게 떠보이거나 탁하게 보이는 문제 개선

## 스크린샷
| Before | After |
|---|---|
| (이미지) | (이미지) |

## 테스트
- [ ] 로컬에서 `npm start`로 레이아웃/폰트/버튼 정상 표시 확인
- [ ] 라이트/다크(있는 경우) 전환 시 대비 문제 없음
- [ ] 브라우저 크롬/엣지 최신에서 시각적 이상 없음

## 기타
- 유지보수 편의를 위해 `Allow edits by maintainers` 체크했습니다.
